### PR TITLE
CVE-2012-3442

### DIFF
--- a/cves/CVE-2012-3442.yml
+++ b/cves/CVE-2012-3442.yml
@@ -15,7 +15,7 @@ curated_instructions: |
   integrity checks on this file to make sure you fill everything out properly.
   If you are a student, we cannot accept your work as finished unless curated is
   set to true.
-curated: false
+curated: true
 reported_instructions: |
   What date was the vulnerability reported to the security team? Look at the
   security bulletins and bug reports. It is not necessarily the same day that the
@@ -28,11 +28,11 @@ announced_instructions: |
   source for this is Chrome's Stable Release Channel
   (https://chromereleases.googleblog.com/).
   Please enter your date in YYYY-MM-DD format.
-announced_date:
+announced_date: "2012-07-30"
 published_instructions: |
   Is there a published fix or patch date for this vulnerability?
   Please enter your date in YYYY-MM-DD format.
-published_date:
+published_date: "2012-07-30"
 description_instructions: |
   You can get an initial description from the CVE entry on cve.mitre.org. These
   descriptions are a fine start, but they can be kind of jargony.
@@ -49,7 +49,15 @@ description_instructions: |
 
   Your target audience is people just like you before you took any course in
   security
-description:
+description: |
+  The login() and logout() views provided in Django's authentication framework
+  make use of the common "POST-redirect-GET" pattern; a configurable 
+  querystring parameter can be used to specify the location to redirect to on
+  successful submission. Currently, those views perform basic validation to ensure
+  that the redirect location does not specify a different domain.
+  However, this validation does not check the scheme of the target URL. An 
+  attacker can craft, for example, a data: scheme URL which would execute 
+  JavaScript, enabling an XSS attack.
 bounty_instructions: |
   If you came across any indications that a bounty was paid out for this
   vulnerability, fill it out here. Or correct it if the information already here
@@ -65,10 +73,12 @@ fixes_vcc_instructions: |
   Please put the commit hash in "commit" below (see my example in
   CVE-2011-3092.yml). Fixes and VCCs follow the same format.
 fixes:
+- commit: 4129201c3e0fa057c198bdefcb34686a23b4a93c
+  note: Commit to master fixing vuln (indicates fixed before disclosure)
 - commit: 4dea4883e6c50d75f215a6b9bcbd95273f57c72d
-  note:
+  note: Backport from master to fix vuln in version 1.3.x
 - commit: e34685034b60be1112160e76091e5aee60149fa1
-  note:
+  note: Backport from master to fix vuln in version 1.4.x
 vccs:
 - commit: 42c31f6bf036efd93c0311bc1f524b1553c20489
   note: This VCC was discovered automatically via archeogit.
@@ -109,10 +119,13 @@ unit_tested:
 
     For the fix_answer below, check if the fix for the vulnerability involves
     adding or improving an automated test to ensure this doesn't happen again.
-  code:
-  code_answer:
-  fix:
-  fix_answer:
+  code: false
+  code_answer: |
+    Author does not disclose how they discovered the vulnerability.
+  fix: true
+  fix_answer: |
+    A unit test called "test_unsafe_redirect" was added to 
+    `tests/regressiontests/httpwrappers/tests.py`
 discovered:
   question: |
     How was this vulnerability discovered?
@@ -126,10 +139,17 @@ discovered:
     The automated, contest, and developer flags can be true, false, or nil.
 
     If there is no evidence as to how this vulnerability was found, then please explain where you looked.
-  answer:
-  automated:
-  contest:
-  developer:
+  answer: |
+    No clear indication of how issue was discovered can be found. Pull request 
+    and commit to Django repo contain no discussion about vuln. Django ticket 
+    system contains only a Changeset reference to the commits to the repo. 
+    There is no ticket mentioning the vulnerability as a bug or otherwise. 
+    Vuln was disclosed and CVE was assigned after fix was merged into repo. 
+    Unable to find any mentions of the vulnerability in Django forums or
+    mailing lists.
+  automated: false
+  contest: false
+  developer: false
 autodiscoverable:
   instructions: |
     Is it plausible that a fully automated tool could have discovered
@@ -144,8 +164,10 @@ autodiscoverable:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  answer_note:
-  answer:
+  answer_note: |
+    A fuzzer inserting arbitrary javascript could have feesably found this bug
+    by inserting a data: field into the redirect.
+  answer: true
 specification:
   instructions: |
     Is there mention of a violation of a specification? For example,
@@ -157,8 +179,8 @@ specification:
 
     The answer field should be boolean. In answer_note, please explain
     why you come to that conclusion.
-  answer_note:
-  answer:
+  answer_note: "nil"
+  answer: false
 subsystem:
   question: |
     What subsystems was the mistake in?
@@ -177,8 +199,8 @@ subsystem:
     In the name field, a subsystem name (or an array of names)
 
     e.g. clipboard, model, view, controller, mod_dav, ui, authentication
-  answer:
-  name:
+  answer: "The file in question resides in the django/django/http directory"
+  name: "http"
 interesting_commits:
   question: |
     Are there any interesting commits between your VCC(s) and fix(es)?
@@ -200,8 +222,8 @@ i18n:
 
     Answer should be boolean. Write a note about how you came to the conclusions
     you did.
-  answer:
-  note:
+  answer: false
+  note: "Failure to check URI scheme was not i18n"
 ipc:
   question: |
     Did the feature that this vulnerability affected use inter-process
@@ -210,8 +232,8 @@ ipc:
     software system reads is another form of IPC.
 
     Answer should be boolean.
-  answer:
-  note:
+  answer: false
+  note: "Failure to check URI scheme involves no IPC"
 lessons:
   question: |
     Are there any common lessons we have learned from class that apply to this
@@ -272,7 +294,13 @@ mistakes:
     Use those questions to inspire your answer. Don't feel obligated to answer
     every one. Write a thoughtful entry here that those ing the software
     engineering industry would find interesting.
-  answer:
+  answer: |
+    The principal mistake was too much trust in the redirect input. Its clear
+    some thought was put into using the redirect as an attack vector, as basic
+    cleansing is done wrt not allowing and redirect off of the domain. However
+    the original author assumed that the redirect would have a scheme of 
+    http(s): so an attack could use a data: (or other type of tag) to still do
+    a malicious redirect.
 CWE_instructions: |
   Please go to http://cwe.mitre.org and find the most specific, appropriate CWE
   entry that describes your vulnerability. We recommend going to
@@ -285,8 +313,11 @@ CWE_instructions: |
 
   Just the number here is fine. No need for name or CWE prefix. If more than one
   apply here, then choose the best one and mention the others in CWE_note.
-CWE:
-CWE_note:
+CWE: 183
+CWE_note: |
+  Before the fix the code for the redirect did ensure that a redirect to an
+  external domain was dissallowed, however it did not disallow "data:" URIs.
+  Therefore the list of allowed inputs was too permissive.
 nickname_instructions: |
   A catchy name for this vulnerability that would draw attention it. If the
   report mentions a nickname, use that. Must be under 30 characters.


### PR DESCRIPTION
Added information about CVE-2012-3442 about an oversight in Django's http subsystem which would allow an attack to perform a malicious redirect from certain views.